### PR TITLE
Fix Option System

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,11 @@ const Sword = (opts = defaultOpts) => ({
 
     ast.findAllRulesByType("rule", (rule) => {
       core.forEach((coreFile) => {
-        require(path.join(__dirname, "./core/", coreFile))(rule, ast);
+        // if the option is enabled, apply desired function to the rule
+        const currOption = coreFile.replace('.js', '');
+        if (opts[currOption]) {
+          require(path.join(__dirname, "./core/", coreFile))(rule, ast);
+        }
       });
     });
 

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -15,7 +15,19 @@ describe("#SwordCSS", () => {
         ".elem{width:100%;height:100%;}#elem{height:100%;width:100%;}"
       );
     });
+
+    // disabled option test
+    it("shouldn't use the class when option is disabled", () => {
+      expect(
+        SwordCSS({ useClass: false })
+          .compile(".elem{width:100%;height:100%;}#elem{sw-class:elem;}")
+          .replace(/[\r\n ]+/gm, "")
+      ).to.equal(
+        ".elem{width:100%;height:100%;}#elem{sw-class:elem;}"
+      );
+    });
   });
+  
   describe(".useId", () => {
     it("should compile correctly", () => {
       expect(
@@ -26,7 +38,19 @@ describe("#SwordCSS", () => {
         ".elem{height:100%;width:100%;}#elem{width:100%;height:100%;}"
       );
     });
+
+    // disabled option test
+    it("shouldn't use the id when option is disabled", () => {
+      expect(
+        SwordCSS({ useId: false })
+          .compile(".elem{sw-id:elem;}#elem{width:100%;height:100%;}")
+          .replace(/[\r\n ]+/gm, "")
+      ).to.equal(
+        ".elem{sw-id:elem;}#elem{width:100%;height:100%;}"
+      );
+    });
   });
+
   describe(".useQuery", () => {
     it("should compile correctly", () => {
       expect(
@@ -37,7 +61,19 @@ describe("#SwordCSS", () => {
         ".elem{height:100%;width:100%;}#elem{width:100%;height:100%;}"
       );
     });
+
+    // disabled option test
+    it("shouldn't use the query when option is disabled", () => {
+      expect(
+        SwordCSS({ useQuery: false })
+          .compile(".elem{sw-query:#elem;}#elem{width:100%;height:100%;}")
+          .replace(/[\r\n ]+/gm, "")
+      ).to.equal(
+        ".elem{sw-query:#elem;}#elem{width:100%;height:100%;}"
+      );
+    });
   });
+
   describe(".useConstant", () => {
     it("should compile correctly", () => {
       expect(
@@ -45,6 +81,17 @@ describe("#SwordCSS", () => {
           .compile("@sw-constants{const1:red;}.elem{color:const1;}")
           .replace(/[\r\n ]+/g, "")
       ).to.equal(".elem{color:red;}");
+    });
+
+    // disabled option test
+    it("shouldn't use the constant when option is disabled", () => {
+      expect(
+        SwordCSS({ useConstant: false })
+          .compile("@sw-constants{const1:red;}.elem{color:const1;}")
+          .replace(/[\r\n ]+/gm, "")
+      ).to.equal(
+        "@sw-constants{const1:red;}.elem{color:const1;}"
+      );
     });
   });
 });


### PR DESCRIPTION
Added a condition to check whether the relative option is set before executing a core function. This is done based on core file name (without extension).
Tests are also updated :+1: 